### PR TITLE
Validate empty lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [1.3.0] - 26.08.2020
 
-## Added
+### Added
 - Validate empty lines
 
 ## [1.2.0] - 23.08.2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [1.3.0] - 26.08.2020
+
+## Added
+- Validate empty lines
+
 ## [1.2.0] - 23.08.2020
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ GitHub Action to validate CHANGELOG.md files and indicate if the changelog shoul
   - Versions should be in decremental order from top to bottom
   - It cannot contain two equal versions
   - Headings should have a correct number of spaces
+  - Headings space before and after
   - H3 headings must be of a valid type
     - Added
     - Changed

--- a/dist/index.js
+++ b/dist/index.js
@@ -9675,6 +9675,13 @@ const validateChangelog = (text) => {
                     lines: [lineNumber],
                 });
             }
+
+            if (lines[i - 1] !== undefined) {
+                errors.push({
+                    message: 'Title should be the fist line of the document',
+                    lines: [lineNumber],
+                });
+            }
         } else if (version) {
             const [, unreleased, versionValue, date] = line.match(reH2) || [];
 
@@ -9697,6 +9704,20 @@ const validateChangelog = (text) => {
             if (!checkHeadingSpaces(line, 2)) {
                 errors.push({
                     message: 'Has incorrect spaces',
+                    lines: [lineNumber],
+                });
+            }
+
+            if (lines[i - 1] !== '') {
+                errors.push({
+                    message: 'A version heading needs an empty line before',
+                    lines: [lineNumber],
+                });
+            }
+
+            if (lines[i + 1] !== '') {
+                errors.push({
+                    message: 'A version heading needs an empty line after',
                     lines: [lineNumber],
                 });
             }
@@ -9731,6 +9752,20 @@ const validateChangelog = (text) => {
             if (!checkHeadingSpaces(line, 3)) {
                 errors.push({
                     message: 'Type has incorrect spaces',
+                    lines: [lineNumber],
+                });
+            }
+
+            if (lines[i - 1] !== '') {
+                errors.push({
+                    message: 'A type heading needs an empty line before',
+                    lines: [lineNumber],
+                });
+            }
+
+            if (lines[i + 1] === '') {
+                errors.push({
+                    message: 'A type heading can\'t have an empty line after',
                     lines: [lineNumber],
                 });
             }

--- a/src/__test__/changelogs/emptyLines.md
+++ b/src/__test__/changelogs/emptyLines.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+
+## Unreleased
+## [0.0.2] - 12.12.2020
+
+### Added
+- Initial Functionality
+- More stuff
+
+### Removed
+- stuff
+
+## [0.0.1] - 11.12.2020
+
+- Init

--- a/src/__test__/validate.test.js
+++ b/src/__test__/validate.test.js
@@ -64,6 +64,11 @@ describe('validateChangelog', () => {
         const nextVersionGreaterThanPrevious = await readFile('./src/__test__/changelogs/duplicatedHeadings.md', {encoding: 'utf-8'});
         expect(() => validateChangelog(nextVersionGreaterThanPrevious)).toThrow('Version "0.0.2" can\'t have repeated headings');
     });
+
+    it('should throw error if for headings with incorrect empty lines', async () => {
+        const nextVersionGreaterThanPrevious = await readFile('./src/__test__/changelogs/emptyLines.md', {encoding: 'utf-8'});
+        expect(() => validateChangelog(nextVersionGreaterThanPrevious)).toThrow('A version heading needs an empty line after');
+    });
 });
 
 describe('compareSemVer', () => {

--- a/src/validate.js
+++ b/src/validate.js
@@ -110,6 +110,13 @@ const validateChangelog = (text) => {
                     lines: [lineNumber],
                 });
             }
+
+            if (lines[i - 1] !== undefined) {
+                errors.push({
+                    message: 'Title should be the fist line of the document',
+                    lines: [lineNumber],
+                });
+            }
         } else if (version) {
             const [, unreleased, versionValue, date] = line.match(reH2) || [];
 
@@ -132,6 +139,20 @@ const validateChangelog = (text) => {
             if (!checkHeadingSpaces(line, 2)) {
                 errors.push({
                     message: 'Has incorrect spaces',
+                    lines: [lineNumber],
+                });
+            }
+
+            if (lines[i - 1] !== '') {
+                errors.push({
+                    message: 'A version heading needs an empty line before',
+                    lines: [lineNumber],
+                });
+            }
+
+            if (lines[i + 1] !== '') {
+                errors.push({
+                    message: 'A version heading needs an empty line after',
                     lines: [lineNumber],
                 });
             }
@@ -166,6 +187,20 @@ const validateChangelog = (text) => {
             if (!checkHeadingSpaces(line, 3)) {
                 errors.push({
                     message: 'Type has incorrect spaces',
+                    lines: [lineNumber],
+                });
+            }
+
+            if (lines[i - 1] !== '') {
+                errors.push({
+                    message: 'A type heading needs an empty line before',
+                    lines: [lineNumber],
+                });
+            }
+
+            if (lines[i + 1] === '') {
+                errors.push({
+                    message: 'A type heading can\'t have an empty line after',
                     lines: [lineNumber],
                 });
             }


### PR DESCRIPTION
Now spaces are required for titles, versions and types headings.

Wrong
```
## Unreleased
## [0.0.2] - 12.12.2020
### Added
- Initial Functionality
- More stuff
```

Correct
```
## Unreleased

## [0.0.2] - 12.12.2020

### Added
- Initial Functionality
- More stuff
```

<img width="280" alt="Screenshot 2020-08-26 at 15 13 30" src="https://user-images.githubusercontent.com/1938043/91307812-b843d380-e7ae-11ea-9465-e81a0b58db58.png">