### PR TITLE
Add version only if is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [1.3.1] - 26.08.2020
+
+### Fixed
+- Validate wrong version headings
+
 ## [1.3.0] - 26.08.2020
 
 ### Added

--- a/dist/index.js
+++ b/dist/index.js
@@ -9722,11 +9722,19 @@ const validateChangelog = (text) => {
                 });
             }
 
-            skeleton.versions.push({
-                value: unreleased || versionValue,
-                lineNumber,
-                date: unreleased || date,
-            });
+            if (unreleased || versionValue) {
+                skeleton.versions.push({
+                    value: unreleased || versionValue,
+                    lineNumber,
+                    date: unreleased || date,
+                });
+            } else {
+                errors.push({
+                    message: 'Is not a valid version',
+                    lines: [lineNumber],
+                });
+            }
+
             lastVersion = unreleased || versionValue;
         } else if (type) {
             const re = `^###\\s+(${changeTypes.join('|')})$`;

--- a/src/validate.js
+++ b/src/validate.js
@@ -157,11 +157,19 @@ const validateChangelog = (text) => {
                 });
             }
 
-            skeleton.versions.push({
-                value: unreleased || versionValue,
-                lineNumber,
-                date: unreleased || date,
-            });
+            if (unreleased || versionValue) {
+                skeleton.versions.push({
+                    value: unreleased || versionValue,
+                    lineNumber,
+                    date: unreleased || date,
+                });
+            } else {
+                errors.push({
+                    message: 'Is not a valid version',
+                    lines: [lineNumber],
+                });
+            }
+
             lastVersion = unreleased || versionValue;
         } else if (type) {
             const re = `^###\\s+(${changeTypes.join('|')})$`;


### PR DESCRIPTION
Previous [run](https://github.com/zattoo/changelog/runs/1031634297) failed because a heading `## Added` had invalid number of `#` causing it to be interpreted as a version heading.

Now version headings are added to the version array if they are valid.

