### PR TITLE
Hotfix 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [1.6.1] - 02.12.2020
+
+Fixed errors not throwing
+
 ## [1.6.0] - 01.12.2020
 
 Added multiple changelogs support

--- a/dist/index.js
+++ b/dist/index.js
@@ -10376,7 +10376,7 @@ const run = async () => {
                     const projectChangelog = changelogs.find((file) => file.includes(`${project}/CHANGELOG.md`));
 
                     if (projectChangelog) {
-                        validateRelease(projectChangelog);
+                        await validateRelease(projectChangelog);
                     } else {
                         throw new Error(`The changelog for project "${project}" must be modified for this release`);
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "changelog",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "changelog",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Detects changes and validates a given changelog",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ const run = async () => {
                     const projectChangelog = changelogs.find((file) => file.includes(`${project}/CHANGELOG.md`));
 
                     if (projectChangelog) {
-                        validateRelease(projectChangelog);
+                        await validateRelease(projectChangelog);
                     } else {
                         throw new Error(`The changelog for project "${project}" must be modified for this release`);
                     }


### PR DESCRIPTION
The project was missing an `await` causing it to not capture the thrown errors.

## [1.6.1] - 02.12.2020

Fixed errors not throwing