### PR TITLE
Hotfix 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [1.6.2] - 08.12.2020
 
-## Fixed
+### Fixed
 - undefined repeated headings
 - longer semantic versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [1.6.2] - 08.12.2020
+
+## Fixed
+- undefined repeated headings
+- longer semantic versions
+
 ## [1.6.1] - 02.12.2020
 
 Fixed errors not throwing

--- a/dist/index.js
+++ b/dist/index.js
@@ -9908,7 +9908,10 @@ const validateChangelog = (text) => {
         if (skeleton.versions[i - 1]
             && skeleton.versions[i - 1].value !== 'Unreleased'
             && skeleton.versions[i - 1].value !== undefined
-            && compareSemVer(skeleton.versions[i - 1].value, version.value) === -1) {
+            && compareSemVer(
+                skeleton.versions[i - 1].value.replace('-', '.'),
+                version.value.replace('-', '.'),
+            ) === -1) {
             errors.push({
                 message: 'Previous version can\'t be smaller than the next one',
                 lines: [skeleton.versions[i - 1].lineNumber, version.lineNumber],
@@ -9918,12 +9921,14 @@ const validateChangelog = (text) => {
 
     // Check duplicated headings for version
     Object.entries(skeleton.versionsContent).forEach(([version, headings]) => {
-        const unrepeatedHeadings = new Set(headings.map((heading) => heading.value));
-        if (unrepeatedHeadings.size !== headings.length) {
-            errors.push({
-                message: `Version "${version}" can't have repeated headings`,
-                lines: [skeleton.versions.find((v) => v.value === version).lineNumber],
-            });
+        if (version) {
+            const unrepeatedHeadings = new Set(headings.map((heading) => heading.value));
+            if (unrepeatedHeadings.size !== headings.length) {
+                errors.push({
+                    message: `Version "${version}" can't have repeated headings`,
+                    lines: [skeleton.versions.find((v) => v.value === version).lineNumber],
+                });
+            }
         }
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "changelog",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "changelog",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Detects changes and validates a given changelog",
   "main": "src/index.js",
   "scripts": {

--- a/src/validate.js
+++ b/src/validate.js
@@ -271,7 +271,10 @@ const validateChangelog = (text) => {
         if (skeleton.versions[i - 1]
             && skeleton.versions[i - 1].value !== 'Unreleased'
             && skeleton.versions[i - 1].value !== undefined
-            && compareSemVer(skeleton.versions[i - 1].value, version.value) === -1) {
+            && compareSemVer(
+                skeleton.versions[i - 1].value.replace('-', '.'),
+                version.value.replace('-', '.'),
+            ) === -1) {
             errors.push({
                 message: 'Previous version can\'t be smaller than the next one',
                 lines: [skeleton.versions[i - 1].lineNumber, version.lineNumber],
@@ -281,12 +284,14 @@ const validateChangelog = (text) => {
 
     // Check duplicated headings for version
     Object.entries(skeleton.versionsContent).forEach(([version, headings]) => {
-        const unrepeatedHeadings = new Set(headings.map((heading) => heading.value));
-        if (unrepeatedHeadings.size !== headings.length) {
-            errors.push({
-                message: `Version "${version}" can't have repeated headings`,
-                lines: [skeleton.versions.find((v) => v.value === version).lineNumber],
-            });
+        if (version) {
+            const unrepeatedHeadings = new Set(headings.map((heading) => heading.value));
+            if (unrepeatedHeadings.size !== headings.length) {
+                errors.push({
+                    message: `Version "${version}" can't have repeated headings`,
+                    lines: [skeleton.versions.find((v) => v.value === version).lineNumber],
+                });
+            }
         }
     });
 


### PR DESCRIPTION
Applying the changelog to the shop showed they were using wrong semantic versioning as `4.0.1.x` this caused the parsing to fail for comparing multiple repeated headings since it returns `undefined` for the version.

We decided to rename those versions to a valid semver `4.0.1-x` and this PR adds a way to compare them.