### PR TITLE
37: Unreleased placement and pre-release order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ### Added
 - [51](https://github.com/zattoo/changelog/issues/51) Ignore files
+- [37](https://github.com/zattoo/changelog/issues/37) Supported alpha version order and `Unreleased` check as first heading
 
 ### Infrastructure
 - Added `v1` back-syncs
+- Added tests for releases
 
 ## [1.6.1] - 02.12.2020
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ GitHub Action to validate CHANGELOG.md files and indicate if the changelog shoul
   - A h1 title must be present
   - Only one h1 heading
   - Only one h2 with unreleased is allowed
+  - Unreleased must be the fist heading
   - H2 should contain a valid version or be unreleased
   - H2 heading should have a proper SemVer
   - H2 should have valid dates
   - No repeated H3 under the same H2
   - Versions should be in decremental order from top to bottom
+  - A greater alfa version can be after a smaller version
   - It cannot contain two equal versions
   - Headings should have a correct number of spaces
   - Headings space before and after

--- a/src/__test__/changelogs/release/ifPreReleaseHasGreaterVersion.md
+++ b/src/__test__/changelogs/release/ifPreReleaseHasGreaterVersion.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [2.2.0] - 01.01.2077
+
+Release description
+
+## [3.0.0-rc.0] - 01.01.2055
+
+Release description
+
+## [2.1.0] - 01.01.2025
+
+Release description

--- a/src/__test__/changelogs/release/mergeConflictAddedByMistakeSameVersions.md
+++ b/src/__test__/changelogs/release/mergeConflictAddedByMistakeSameVersions.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [2.0.0] - 01.01.2077
+
+Release description
+
+## [2.0.0] - 01.01.2077
+
+Release description
+
+## [1.9.0] - 01.01.2025
+
+Release description

--- a/src/__test__/changelogs/release/unreleasedVersionPlacedBetweenReleasedVersions.md
+++ b/src/__test__/changelogs/release/unreleasedVersionPlacedBetweenReleasedVersions.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [2.0.0] - 01.01.2077
+
+Release description
+
+## Unreleased
+
+Hotfix description
+
+## [1.9.0] - 01.01.2025
+
+Release description

--- a/src/__test__/changelogs/release/versionWasAddedInWrongTimeline.md
+++ b/src/__test__/changelogs/release/versionWasAddedInWrongTimeline.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [2.0.0] - 01.01.2077
+
+Release description
+
+## [2.1.0] - 15.01.2077
+
+Hotfix description
+
+## [1.9.0] - 01.01.2025
+
+Release description

--- a/src/__test__/changelogs/release/wrongVersionWasPatched.md
+++ b/src/__test__/changelogs/release/wrongVersionWasPatched.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [1.9.1] - 15.01.2077
+
+Hotfix description
+
+## [2.0.0] - 01.01.2077
+
+Release description
+
+## [1.9.0] - 01.01.2025
+
+Release description

--- a/src/__test__/validate.test.js
+++ b/src/__test__/validate.test.js
@@ -69,6 +69,38 @@ describe('validateChangelog', () => {
         const nextVersionGreaterThanPrevious = await readFile('./src/__test__/changelogs/emptyLines.md', {encoding: 'utf-8'});
         expect(() => validateChangelog(nextVersionGreaterThanPrevious)).toThrow('A version heading needs an empty line after');
     });
+
+    /**
+     * Release tests
+     *
+     * @see https://github.com/zattoo/changelog/issues/37
+     */
+    it('should throw error if wrong version was patched', async () => {
+        const nextVersionGreaterThanPrevious = await readFile('./src/__test__/changelogs/release/wrongVersionWasPatched.md', {encoding: 'utf-8'});
+        expect(() => validateChangelog(nextVersionGreaterThanPrevious)).toThrow('Previous version can\'t be smaller than the next one');
+    });
+
+    it('should throw error if version was added in wrong timeline', async () => {
+        const nextVersionGreaterThanPrevious = await readFile('./src/__test__/changelogs/release/versionWasAddedInWrongTimeline.md', {encoding: 'utf-8'});
+        expect(() => validateChangelog(nextVersionGreaterThanPrevious)).toThrow('Previous version can\'t be smaller than the next one');
+    });
+
+    it('should throw error if unreleased version placed between released versions', async () => {
+        const nextVersionGreaterThanPrevious = await readFile('./src/__test__/changelogs/release/unreleasedVersionPlacedBetweenReleasedVersions.md', {encoding: 'utf-8'});
+        expect(() => validateChangelog(nextVersionGreaterThanPrevious)).toThrow('Unreleased version must be the fist version heading');
+    });
+
+    it('should throw error if merge conflict added by mistake in same versions', async () => {
+        const nextVersionGreaterThanPrevious = await readFile('./src/__test__/changelogs/release/mergeConflictAddedByMistakeSameVersions.md', {encoding: 'utf-8'});
+        expect(() => validateChangelog(nextVersionGreaterThanPrevious)).toThrow('Version repeated on lines');
+    });
+
+    it('should be valid if pre-release has greater version', async () => {
+        const changelogContent = await readFile('./src/__test__/changelogs/release/ifPreReleaseHasGreaterVersion.md', {encoding: 'utf-8'});
+        const {skeleton} = validateChangelog(changelogContent);
+        expect(skeleton.versions[0].value).toBe('2.2.0');
+        expect(skeleton.versions[1].value).toBe('3.0.0-rc.0');
+    });
 });
 
 describe('compareSemVer', () => {

--- a/src/validate.js
+++ b/src/validate.js
@@ -34,6 +34,9 @@ const checkHeadingSpaces = (text, level) => {
 
 /**
  * Checks if the given version is not released yet
+ *
+ * @param {string} version
+ * @returns {boolean}
  */
 const isPrerelease = (version) => {
     const lowerCasedVersion = version.toLowerCase();

--- a/src/validate.js
+++ b/src/validate.js
@@ -33,6 +33,15 @@ const checkHeadingSpaces = (text, level) => {
 };
 
 /**
+ * Checks if the given version is not released yet
+ */
+const isPrerelease = (version) => {
+    const lowerCasedVersion = version.toLowerCase();
+    const preReleases = ['alpha', 'rc', 'beta', 'dev'];
+    return preReleases.some((name) => lowerCasedVersion.includes(name));
+};
+
+/**
  * If the semver string a is greater than b, return 1.
  * If the semver string b is greater than a, return -1.
  *
@@ -251,6 +260,15 @@ const validateChangelog = (text) => {
         });
     }
 
+    // Check if unreleased version is the first heading if present
+    const unreleasedIndex = skeleton.versions.findIndex((version) => version.value.toLowerCase().includes('unreleased'));
+    if (unreleasedIndex > 0) {
+        errors.push({
+            message: 'Unreleased version must be the fist version heading',
+            lines: [skeleton.versions[unreleasedIndex].lineNumber],
+        });
+    }
+
     // Check repeated versions
     const repeatedCounts = skeleton.versions.reduce((acc, version) => {
         acc[version.value] = ++acc[version.value] || 0;
@@ -271,7 +289,8 @@ const validateChangelog = (text) => {
         if (skeleton.versions[i - 1]
             && skeleton.versions[i - 1].value !== 'Unreleased'
             && skeleton.versions[i - 1].value !== undefined
-            && compareSemVer(skeleton.versions[i - 1].value, version.value) === -1) {
+            && compareSemVer(skeleton.versions[i - 1].value, version.value) === -1
+            && !isPrerelease(version.value)) {
             errors.push({
                 message: 'Previous version can\'t be smaller than the next one',
                 lines: [skeleton.versions[i - 1].lineNumber, version.lineNumber],


### PR DESCRIPTION
Most cases present in the PR were already checked by the action, I added test for all the examples.

Two functionalities were missing, support`If pre-release has greater version` and `Unreleased version placed between released versions`, this functionality has been added also with tests.

Fixes: https://github.com/zattoo/changelog/issues/37