### PR TITLE
60: Add error logic for delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+
+### Fixed
 - [60](https://github.com/zattoo/changelog/issues/60) Supported validation of separator between version and date
 
 ## [1.7.0] - 11.06.2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## Unreleased
+- [60](https://github.com/zattoo/changelog/issues/60) Supported validation of separator between version and date
 
 ## [1.7.0] - 11.06.2021
+
 ### Added
 - [51](https://github.com/zattoo/changelog/issues/51) Ignore files
 - [37](https://github.com/zattoo/changelog/issues/37) Supported alpha version order and `Unreleased` check as first heading
 - [49](https://github.com/zattoo/changelog/issues/49) Limited release branch to ask for modified files only of its own project
-- [60](https://github.com/zattoo/changelog/issues/60) Supported validation of separator between version and date
 
 ### Infrastructure
 - Added `v1` back-syncs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - [51](https://github.com/zattoo/changelog/issues/51) Ignore files
 - [37](https://github.com/zattoo/changelog/issues/37) Supported alpha version order and `Unreleased` check as first heading
 - [49](https://github.com/zattoo/changelog/issues/49) Limited release branch to ask for modified files only of its own project
+- [60](https://github.com/zattoo/changelog/issues/60) Supported validation of separator between version and date
 
 ### Infrastructure
 - Added `v1` back-syncs

--- a/dist/index.js
+++ b/dist/index.js
@@ -9653,7 +9653,7 @@ const changeTypes = [
  *
  * @see https://regex101.com/r/v5VmTx/2
  */
-const reH2 = /^##\s\[?(Unreleased)\]?|^##\s\[((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\] - (Unreleased|(?:\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d))$/;
+const reH2 = /^##\s\[?(Unreleased)\]?|^##\s\[((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\]\s*\W\s*(Unreleased|(?:\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d))$/;
 
 /**
  * Validates if the given text heading
@@ -9780,6 +9780,13 @@ const validateChangelog = (text) => {
             }
         } else if (version) {
             const [, unreleased, versionValue, date] = line.match(reH2) || [];
+
+            if (!line.includes(' - ')) {
+                errors.push({
+                    message: 'Use a valid dash separation " - " between the version and date',
+                    lines: [lineNumber],
+                });
+            }
 
             if (!isUnreleased(unreleased, date)) {
                 if (!date) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -9781,14 +9781,14 @@ const validateChangelog = (text) => {
         } else if (version) {
             const [, unreleased, versionValue, date] = line.match(reH2) || [];
 
-            if (!line.includes(' - ')) {
-                errors.push({
-                    message: 'Use a valid dash separation " - " between the version and date',
-                    lines: [lineNumber],
-                });
-            }
-
             if (!isUnreleased(unreleased, date)) {
+                if (!line.includes(' - ')) {
+                    errors.push({
+                        message: 'Use a valid dash separation " - " between the version and date',
+                        lines: [lineNumber],
+                    });
+                }
+
                 if (!date) {
                     errors.push({
                         message: 'A valid date is required for a version',

--- a/src/__test__/changelogs/wrongSeparator.md
+++ b/src/__test__/changelogs/wrongSeparator.md
@@ -1,0 +1,7 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [1.0.0] – 29.06.2020
+
+### Added
+- New functionality

--- a/src/__test__/validate.test.js
+++ b/src/__test__/validate.test.js
@@ -25,6 +25,11 @@ describe('validateChangelog', () => {
         expect(() => validateChangelog('')).toThrow('No title is present');
     });
 
+    it('should throw error for wrong separator', async () => {
+        const wrongSeparator = await readFile('./src/__test__/changelogs/wrongSeparator.md', {encoding: 'utf-8'});
+        expect(() => validateChangelog(wrongSeparator)).toThrow('Use a valid dash separation " - " between the version and date');
+    });
+
     it('should throw error for more than one title', async () => {
         const multipleH1 = await readFile('./src/__test__/changelogs/twoTitles.md', {encoding: 'utf-8'});
         expect(() => validateChangelog(multipleH1)).toThrow('Only one title is allowed');

--- a/src/validate.js
+++ b/src/validate.js
@@ -144,14 +144,14 @@ const validateChangelog = (text) => {
         } else if (version) {
             const [, unreleased, versionValue, date] = line.match(reH2) || [];
 
-            if (!line.includes(' - ')) {
-                errors.push({
-                    message: 'Use a valid dash separation " - " between the version and date',
-                    lines: [lineNumber],
-                });
-            }
-
             if (!isUnreleased(unreleased, date)) {
+                if (!line.includes(' - ')) {
+                    errors.push({
+                        message: 'Use a valid dash separation " - " between the version and date',
+                        lines: [lineNumber],
+                    });
+                }
+
                 if (!date) {
                     errors.push({
                         message: 'A valid date is required for a version',

--- a/src/validate.js
+++ b/src/validate.js
@@ -16,7 +16,7 @@ const changeTypes = [
  *
  * @see https://regex101.com/r/v5VmTx/2
  */
-const reH2 = /^##\s\[?(Unreleased)\]?|^##\s\[((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\] - (Unreleased|(?:\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d))$/;
+const reH2 = /^##\s\[?(Unreleased)\]?|^##\s\[((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\]\s*\W\s*(Unreleased|(?:\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d))$/;
 
 /**
  * Validates if the given text heading
@@ -143,6 +143,13 @@ const validateChangelog = (text) => {
             }
         } else if (version) {
             const [, unreleased, versionValue, date] = line.match(reH2) || [];
+
+            if (!line.includes(' - ')) {
+                errors.push({
+                    message: 'Use a valid dash separation " - " between the version and date',
+                    lines: [lineNumber],
+                });
+            }
 
             if (!isUnreleased(unreleased, date)) {
                 if (!date) {


### PR DESCRIPTION
The parsing of date and version will not fail given a wrong delimiter, and it will display an error in the case of of using the wrong character

fixes: #60

<img width="602" alt="Screenshot 2021-10-27 at 17 27 55" src="https://user-images.githubusercontent.com/1938043/139097321-5317ba5b-0aed-4782-8182-e706d95d87c5.png">