### PR TITLE
65: Support Yanked versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## Unreleased
 
+### Added
+- [65](https://github.com/zattoo/changelog/issues/65) Supported [Yanked](https://keepachangelog.com/en/1.0.0/#yanked) releases
+
 ### Fixed
 - [60](https://github.com/zattoo/changelog/issues/60) Supported validation of separator between version and date
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -9633,7 +9633,9 @@ module.exports = parse;
 /***/ }),
 
 /***/ 601:
-/***/ (function(module) {
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+const core = __webpack_require__(470);
 
 const changeTypes = [
     'Added',
@@ -9978,6 +9980,13 @@ const validateChangelog = (text) => {
 
     // Return the last version
     const latestVersion = skeleton.versions[0];
+
+    /**
+     *  Debug using `ACTIONS_STEP_DEBUG` to true
+     *
+     * @see https://github.com/actions/toolkit/blob/HEAD/docs/action-debugging.md#step-debug-logs
+     */
+    core.debug(skeleton);
 
     return {
         isUnreleased: isUnreleased(latestVersion.unreleased, latestVersion.date),

--- a/dist/index.js
+++ b/dist/index.js
@@ -10458,6 +10458,7 @@ const run = async () => {
             }
         }
     } catch (error) {
+        core.debug(error.stack);
         core.setFailed(error.message);
     }
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -9651,9 +9651,9 @@ const changeTypes = [
  * Capture Group 1: Version | Unreleased
  * Capture Group 2: Date | Unreleased
  *
- * @see https://regex101.com/r/v5VmTx/2
+ * @see https://regex101.com/r/ZQdEy6/1
  */
-const reH2 = /^##\s\[?(Unreleased)\]?|^##\s\[((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\]\s*\W\s*(Unreleased|(?:\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d))$/;
+const reH2 = /^##\s\[?(Unreleased)\]?|^##\s\[((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\]\s*\W\s*(Unreleased|(?:\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d))( \[YANKED\])?$/;
 
 /**
  * Validates if the given text heading

--- a/src/__test__/changelogs/valid.md
+++ b/src/__test__/changelogs/valid.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [2.0.0] - 04.08.2022 [YANKED]
+
+### Added
+- Initial Functionality
+
 ## [1.0.0] - 29.06.2020
 
 ### Added

--- a/src/__test__/validate.test.js
+++ b/src/__test__/validate.test.js
@@ -17,8 +17,8 @@ describe('validateChangelog', () => {
             isUnreleased, version, date,
         } = validateChangelog(changelogContent);
         expect(isUnreleased).toBe(false);
-        expect(version).toBe('1.0.0');
-        expect(date).toBe('29.06.2020');
+        expect(version).toBe('2.0.0');
+        expect(date).toBe('04.08.2022');
     });
 
     it('should throw error for not title present', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,7 @@ const run = async () => {
             }
         }
     } catch (error) {
+        core.debug(error.stack);
         core.setFailed(error.message);
     }
 };

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,3 +1,5 @@
+const core = require('@actions/core');
+
 const changeTypes = [
     'Added',
     'Changed',
@@ -341,6 +343,13 @@ const validateChangelog = (text) => {
 
     // Return the last version
     const latestVersion = skeleton.versions[0];
+
+    /**
+     *  Debug using `ACTIONS_STEP_DEBUG` to true
+     *
+     * @see https://github.com/actions/toolkit/blob/HEAD/docs/action-debugging.md#step-debug-logs
+     */
+    core.debug(skeleton);
 
     return {
         isUnreleased: isUnreleased(latestVersion.unreleased, latestVersion.date),

--- a/src/validate.js
+++ b/src/validate.js
@@ -14,9 +14,9 @@ const changeTypes = [
  * Capture Group 1: Version | Unreleased
  * Capture Group 2: Date | Unreleased
  *
- * @see https://regex101.com/r/v5VmTx/2
+ * @see https://regex101.com/r/ZQdEy6/1
  */
-const reH2 = /^##\s\[?(Unreleased)\]?|^##\s\[((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\]\s*\W\s*(Unreleased|(?:\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d))$/;
+const reH2 = /^##\s\[?(Unreleased)\]?|^##\s\[((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\]\s*\W\s*(Unreleased|(?:\d\d?\d?\d?[-/.]\d\d?[-/.]\d\d?\d?\d))( \[YANKED\])?$/;
 
 /**
  * Validates if the given text heading


### PR DESCRIPTION
As referred in the FAQ, changelog should support [YANKED] versions: https://keepachangelog.com/en/1.0.0/#yanked

This PR enables support for versions like `## 0.0.5 - 2014-12-13 [YANKED]`

```markdown
Yanked releases are versions that had to be pulled because of a serious bug or security issue. Often these versions don't even appear in change logs. They should. This is how you should display them:

## 0.0.5 - 2014-12-13 [YANKED]

The [YANKED] tag is loud for a reason. It's important for people to notice it. Since it's surrounded by brackets it's also easier to parse programmatically.
```
It also enables debug for the action

fixes: #65